### PR TITLE
Allow configuration of server and client ports and URLs during deployment

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_SERVER_URL=http://localhost:3000

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "node server.js & vite; fg",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "node server.js",
     "dev": "node server.js & vite; fg",
     "build": "tsc && vite build",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "socket-prototype",
   "private": true,
   "version": "0.0.0",
+  "engines": {
+    "node": "16.x.x"
+  },
   "type": "module",
   "scripts": {
     "start": "node server.js",

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ app.use(cors()); // enables CORS
 const server = http.createServer(app);
 const io = new Server(server, {
     cors: {
-        origin: "http://localhost:5176", // neds to update to the correct port/vite url
+        origin: process.env.CLIENT_URL || "http://localhost:5173",
         methods: ["GET", "POST"]
     },
 });
@@ -22,5 +22,6 @@ io.on('connection', socket => {
     // add event listeners
 });
 
-server.listen(3000, () => console.log('server running on: port 3000'));
+const port = process.env.PORT || 3000
+server.listen(port, () => console.log('server running on: port ' + port));
 

--- a/src/scenes/test.ts
+++ b/src/scenes/test.ts
@@ -9,7 +9,7 @@ export class Test extends Phaser.Scene {
   create() {
     this.add.text(0, 0, 'Hello World', { color: 'white' });
 
-    const socket = io("http://localhost:3000");
+    const socket = io(import.meta.env.VITE_SERVER_URL);
     socket.on('connect', () => {
       console.log('connected to server: ' + socket.id);
     });


### PR DESCRIPTION
These changes allow for the front-end and back-end instances to be deployed on different platforms (e.g. Netlify, Glitch) and configure where the client should connect and what domain origin the back-end server should allow connections from.

A quick instruction guide on how this would be used to deploy:
1. Deploy this repository on Netlify.
2. Deploy this repository on Glitch.
3. You should have two deploy URLs now: e.g. `https://example.netlify.app` and `https://example.glitch.me`. **It is important that you copy these URLs in this exact format - do not omit the protocol, or add a trailing slash.**
4. In Netlify, go to "Site configuration" > "Environment variables". Create a new environment variable called `VITE_SERVER_URL` and enter your server back-end URL, e.g. `https://example.glitch.me`.
5. After creating your environment variable, go to "Deploys" under your Netlify site and select "Trigger deploy" to re-build and re-deploy the front-end site.
6. In the editor for your Glitch deploy, go to `.env` and create a new environment variable called `CLIENT_URL`. Enter your Netlify URL, e.g. `https://example.netlify.app`.
7. Confirm that Glitch reloaded the server successfully. The "Status" symbol should be a smiling emoji, and the logs should display "server running on: port XXXX". This console should also print "new user connected" when opening the Netlify page.
8. The website and back-end server have been successfully deployed.